### PR TITLE
Security revisions 1

### DIFF
--- a/draft-ietf-homenet-front-end-naming-delegation.mkd
+++ b/draft-ietf-homenet-front-end-naming-delegation.mkd
@@ -505,7 +505,7 @@ exchange is OPTIONAL.
 
 By accepting the DS, the DM commits in taking care of advertising
 the DS to the parent zone. Upon refusal, the DM MUST clearly indicate
-the DM does not have the capacity to proceed to the update.  
+the DM does not have the capacity to proceed to the update.
 
 ## Information to set the Synchronization Channel,
 
@@ -520,12 +520,12 @@ those used by the Control Channel. By default, the same IP address used
 by the HNA is considered by the DM. Exchange of this information is
 OPTIONAL.
 
-## Deleting the delegation 
+## Deleting the delegation
 
 The purpose of the previous sections were to exchange information in
 order to set a delegation. The HNA MUST also be able to delete a
 delegation with a specific DM. Upon an instruction of deleting the
-delegation, the DM MUST stop serving the Public Homenet Zone. 
+delegation, the DM MUST stop serving the Public Homenet Zone.
 
 ## Messages Exchange Description {#sec-ctrl-messages}
 
@@ -547,7 +547,7 @@ The provisioning process SHOULD provide a method of securing the control
 channel, so that the content of messages can be authenticated. This
 authentication MAY be based on certificates for both the DM and each
 HNA. The DM may also create the initial configuration for the delegation
-zone in the parent zone during the provisioning process.  
+zone in the parent zone during the provisioning process.
 
 ### Retrieving information for the Public Homenet Zone.
 
@@ -636,7 +636,7 @@ Registered Homenet Domain. The Update section MUST be a RRset of Type
 NS. The NAME associated to the NS RRSet MUST be the Registered Domain
 Name. As indictaed by {{!RFC2136}} section 2.5.2 the delete instruction
 is set by setting the TTL to 0, the CLass to ANY, the RDLENGTH to 0 and
-the RDATA MUST be empty.   
+the RDATA MUST be empty.
 
 
 ## Securing the Control Channel between HNA and DM {#sec-ctrl-security}
@@ -759,7 +759,7 @@ The Homenet Reverse Zone MAY also be updated either with DNS UPDATE
 
 ## Securing the Synchronization Channel between HNA and DM {#sec-synch-security}
 
-The Synchronization Channel used standard DNS request. 
+The Synchronization Channel used standard DNS request.
 
 First the primary notifies the secondary that the zone must be updated
 and eaves the secondary to proceed with the update when possible/
@@ -1259,13 +1259,13 @@ Andrew and Peter Koch for clarifying the renumbering.
 
 A number of deployment have been envisionned, this section aims at
 providing a brief description. The use cases are not limitatives and
-this section is not normative. 
+this section is not normative.
 
 ### CPE Vendor
 
 A specific vendor with specific relations with a registrar or a registry
 may sell a CPE that is provisioned with provisioned domain name. Such
-domain name does not need to be necessary human readable. 
+domain name does not need to be necessary human readable.
 
 One possible way is that the vendor also provisions the HNA with a
 private and public keys as well as a certificate. Note that these keys
@@ -1275,22 +1275,22 @@ keys should be necessary and sufficient to proceed to the
 authentication. The reason to combine the domain name and the key is
 that outsourcing infrastructure are likely handle names better than
 keys and that domain names might be used as a login which enables the
-key to be regenerated. 
+key to be regenerated.
 
 When the home network owner plugs the CPE at home, the relation between
-HNA and DM is expected to work out-of-the-box. 
+HNA and DM is expected to work out-of-the-box.
 
 ### Agnostic CPE
 
 An CPE that is not preconfigured may also take advanatge to the protocol
-defined in this document but some configuration steps will be needed. 
+defined in this document but some configuration steps will be needed.
 
 1. The owner of the home network buys a domain name to a registrar, and
 as such creates an account on that registrar
 
 2. Either the registrar is also providing the outsourcing infrastructure
 or the home network needs to create a specific account on the
-outsourcing infrastructure. 
+outsourcing infrastructure.
   * If the outsourcing provider is the registrar, the outsourcing has by
 design a proof of ownership of the domain name by the homenet owner. In
 this case, it is expected the infrastructure provides the necessary
@@ -1300,7 +1300,7 @@ copy/paste a JSON object. What matters at that point is the outsourcing
 infrastructure being able to generate authentication credentials for the
 HNA to authenticate itself to the outsourcing infrastructure. This
 obviously requires the home network to provide the public key gnerated
-by the HNA in a CSR. 
+by the HNA in a CSR.
 
   * If the outsourcing infrastructure is
 not the registrar, then the proof of ownership needs to be established
@@ -1308,7 +1308,7 @@ using protocols like ACME for example that will end in the generation of
 a certificate. ACME is used here to the purpose of automating the
 generation of the certificate, the CA may be a specific CA or the
 outsourcing infrastructure. With that being done, the outsourcing
-infrastructure has a roof of ownership and can proceed as above. 
+infrastructure has a roof of ownership and can proceed as above.
 
 
 ## Example: Homenet Zone {#sec-homenet-zone}

--- a/draft-ietf-homenet-front-end-naming-delegation.mkd
+++ b/draft-ietf-homenet-front-end-naming-delegation.mkd
@@ -947,7 +947,7 @@ It provides suggestions on operational consideration.  TBD.
 # provisioning of the Homenet Naming Authority (HNA) {#hna-provisioning}
 
 This document does not deal with how the HNA is provisioned with a trusted relationship to the Distribution Master for the forward zone.
-Provisioning of the relationship with an ISP-connection specific Distribution Master for reverse zones is dealt with in REFERENCE-TO-MGLT-DHCPV6-PD-WORK.
+Provisioning of the relationship with an ISP-connection specific Distribution Master for reverse zones is dealt with in {{?I-D.ietf-homenet-naming-architecture-dhc-options}}
 
 This section details what needs to be provisioned into the HNA and serves as a requirements statement for mechanisms.
 

--- a/draft-ietf-homenet-front-end-naming-delegation.mkd
+++ b/draft-ietf-homenet-front-end-naming-delegation.mkd
@@ -639,7 +639,7 @@ is set by setting the TTL to 0, the CLass to ANY, the RDLENGTH to 0 and
 the RDATA MUST be empty.
 
 
-## Securing the Control Channel between HNA and DM {#sec-ctrl-security}
+## Securing the Control Channel between Homenet Naming Authority (HNA) and Distribution Master (DM)  {#sec-ctrl-security}
 
 The control channel between the HNA and the DM MUST be secured at both
 the HNA and the DM.

--- a/draft-ietf-homenet-front-end-naming-delegation.mkd
+++ b/draft-ietf-homenet-front-end-naming-delegation.mkd
@@ -658,6 +658,7 @@ service port.  This document RECOMMENDS this option.
 The HNA SHOULD authenticate inbound connections from the DM using
 standard mechanisms, such as a public certificate with baked-in root
 certificates on the HNA, or via DANE {!RFC6698}}.
+The HNA is expected to be provisioned with a connection to the DM by the manufacturer, or during some user-initiated onboarding process, see {{hna-provisioning}}.
 
 The DM SHOULD authenticate the HNA and check that inbound messages are
 from the appropriate client.  The DM MAY use a self-signed CA
@@ -958,6 +959,14 @@ home networks.
 
 This section is non-normative.
 It provides suggestions on operational consideration.  TBD.
+
+# provisioning of the Homenet Naming Authority (HNA) {#hna-provisioning}
+
+This document does not deal with how the HNA is provisioned with a trusted relationship to the Distribution Master for the forward zone.
+Provisioning of the relationship with an ISP-connection specific Distribution Master for reverse zones is dealt with in REFERENCE-TO-MGLT-DHCPV6-PD-WORK.
+
+This section details what needs to be provisioned into the HNA and serves as a requirements statement for mechanisms.
+
 
 # Privacy Considerations {#sec-privacy}
 

--- a/draft-ietf-homenet-front-end-naming-delegation.mkd
+++ b/draft-ietf-homenet-front-end-naming-delegation.mkd
@@ -649,11 +649,9 @@ used to secure the transactions between the DM and the HNA.
 
 The advantage of TLS/DTLS is that this technology is widely deployed,
 and most of the devices already embed TLS/DTLS libraries, possibly also
-taking advantage of hardware acceleration. Further, TLS/DTLS provides
-authentication facilities and can use certificates to authenticate the
-DM and the HNA. On the other hand, using TLS/DTLS
-requires implementing DNS exchanges over TLS/DTLS, as well as a new
-service port.  This document RECOMMENDS this option.
+taking advantage of hardware acceleration.
+Further, TLS/DTLS provides authentication facilities and can use certificates to  mutually authenticate the DM and HNA at the applicationlayer, including available API.
+On the other hand, using TLS/DTLS requires implementing DNS exchanges over TLS/DTLS, as  well as a new service port.
 
 The HNA SHOULD authenticate inbound connections from the DM using
 standard mechanisms, such as a public certificate with baked-in root
@@ -661,36 +659,22 @@ certificates on the HNA, or via DANE {!RFC6698}}.
 The HNA is expected to be provisioned with a connection to the DM by the manufacturer, or during some user-initiated onboarding process, see {{hna-provisioning}}.
 
 The DM SHOULD authenticate the HNA and check that inbound messages are
-from the appropriate client.  The DM MAY use a self-signed CA
-certificate mechanism per HNA, or public certificates for this purpose.
+from the appropriate client.
+The DM MAY use a self-signed CA certificate mechanism per HNA, or public certificates for this purpose.
 
-IPsec {{!RFC4301}} IKEv2 {{!RFC7296}} MAY also be used to secure
-transactions between the HNA and the DM. Similarly to TLS/DTLS, most
-HNAs already embed an IPsec stack, and IKEv2 supports multiple
-authentication mechanisms via the EAP framework. In addition, IPsec can
-be used to protect DNS exchanges between the HNA and the DM without any
-modifications of the DNS server or client. DNS integration over IPsec
-only requires an additional security policy in the Security Policy
-Database (SPD). One disadvantage of IPsec is that NATs and firewall
-traversal may be problematic. However, in our case, the HNA is connected
-to the Internet, and IPsec communication between the HNA and the DM
-should not be impacted by middle boxes.
+IPsec {{!RFC4301}} and IKEv2 {{!RFC7296}} were considered.
+They would need to operate in transport mode, and the authenticated end points would need to be visible to the applications, and this is not commonly available at the time of this writing.
 
-How the PSK can be used by any of the TSIG, TLS/DTLS or IPsec protocols:
-Authentication based on certificates implies a mutual authentication and
-thus requires the HNA to manage a private key, a public key, or
-certificates, as well as Certificate Authorities. This adds complexity
-to the configuration especially on the HNA side. For this reason, we
-RECOMMEND that the HNA MAY use PSK or certificate based authentication,
-and that the DM MUST support PSK and certificate based authentication.
+A pure DNS solution using TSIG and/or SIG(0) to authenticate message was also considered.
+{{hna-provisioning}} envisions one mechanism would involve the end user, with a browser, signing up to a service provider, with a resulting OAUTH2 token to be provided to the HNA.
+A way to translate this OAUTH2 token from HTTPS web space to DNS SIG(0) space seems overly problematic, and so the enrollment protocol using web APIs was determined to be easier to implement at scale.
 
 Note also that authentication of message exchanges between the HNA and
 the DM SHOULD NOT use the external IP address of the HNA to index the
-appropriate keys. As detailed in {{sec-renumbering}}, the IP addresses
-of the DM and the Hidden Primary are subject to change, for example
-while the network is being renumbered. This means that the necessary
-keys to authenticate transaction SHOULD NOT be indexed using the IP
-address, and SHOULD be resilient to IP address changes.
+appropriate keys.
+As detailed in {{sec-renumbering}}, the IP addresses of the DM and the Hidden Primary are subject to change, for example while the network is being renumbered.
+This means that the necessary keys to authenticate transaction SHOULD NOT be indexed  using the IP address, and SHOULD be resilient to IP address changes.
+This should apply to any OAUTH2 token produced as envisioned by {{hna-provisioning}}.
 
 ## Implementation Tips {#sec-ctrl-implementation}
 
@@ -1444,8 +1428,7 @@ exchange is required. Otherwise, the IP addresses should be entered
 manually.
 
 * Authentication Method: How the HNA authenticates itself to the
-DM. This MAY depend on the implementation but this
-should cover at least IPsec, DTLS and TSIG
+DM.
 
 * Authentication data: Associated Data. PSK only requires a single
 argument. If other authentication mechanisms based on certificates are

--- a/draft-ietf-homenet-front-end-naming-delegation.mkd
+++ b/draft-ietf-homenet-front-end-naming-delegation.mkd
@@ -1262,15 +1262,15 @@ for their feedback on handling different views as well as clarifying the
 impact of outsourcing the zone signing operation outside the HNA; Mark
 Andrew and Peter Koch for clarifying the renumbering.
 
-# Annex
+--- back
 
-## Envisioned deployment scenarios
+# Envisioned deployment scenarios
 
 A number of deployment have been envisionned, this section aims at
 providing a brief description. The use cases are not limitatives and
 this section is not normative.
 
-### CPE Vendor
+## CPE Vendor
 
 A specific vendor with specific relations with a registrar or a registry
 may sell a CPE that is provisioned with provisioned domain name. Such
@@ -1289,7 +1289,7 @@ key to be regenerated.
 When the home network owner plugs the CPE at home, the relation between
 HNA and DM is expected to work out-of-the-box.
 
-### Agnostic CPE
+## Agnostic CPE
 
 An CPE that is not preconfigured may also take advanatge to the protocol
 defined in this document but some configuration steps will be needed.
@@ -1320,7 +1320,7 @@ outsourcing infrastructure. With that being done, the outsourcing
 infrastructure has a roof of ownership and can proceed as above.
 
 
-## Example: Homenet Zone {#sec-homenet-zone}
+# Example: Homenet Zone {#sec-homenet-zone}
 
 This section is not normative and intends to illustrate how the HNA
 builds the Homenet Zone.
@@ -1425,7 +1425,7 @@ preferred for large Homenet Zones, or when the number
 of Registered Homenet Domain becomes quite large.
 -->)
 
-## Example: HNA necessary parameters for outsourcing {#sec-configuration-parameters}
+# Example: HNA necessary parameters for outsourcing {#sec-configuration-parameters}
 
 This section specifies the various parameters required by the HNA to
 configure the naming architecture of this document. This section is


### PR DESCRIPTION
This clears up the IPsec references, adding a new section on provisioning that needs to be fleshed out.  #29 tracks this.
This documents IPsec requirements (needs API and transport mode) and SIG(0) (needs interface to OAUTH2), settling for the onboarding process being a WebAPI, while the DNS transfer is IXFR/AXFR over DTLS.